### PR TITLE
Add Custom DC test env file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ screenshots/screenshot_url.json
 .idea
 !.vscode/launch.json
 .env.list
+build/cdc/dev/.env-test
 
 # Mac
 .DS_Store


### PR DESCRIPTION
This file is pulled from Secret Manager by `ensure_cdc_test_env_file` in run_test.sh.